### PR TITLE
Update manifest for v11

### DIFF
--- a/module.json
+++ b/module.json
@@ -8,7 +8,7 @@
   }],
   "version": "This is auto replaced",
   "compatibility": {
-    "minimum": "0.8.0",
+    "minimum": "11",
     "verified": "11"
   },
   "esmodules": ["scripts/main.js"],

--- a/module.json
+++ b/module.json
@@ -1,15 +1,22 @@
 {
-  "name": "hourglass",
+  "id": "hourglass",
   "title": "Hourglass",
   "description": "Configurable animated graphical timers & round trackers that can be shown by the GM to all players.",
-  "author": "Octarine",
+  "authors": [{
+    "name": "Octarine",
+    "email": "octarinefoundry@gmail.com"
+  }],
   "version": "This is auto replaced",
-  "minimumCoreVersion": "0.8.0",
-  "compatibleCoreVersion": "11",
+  "compatibility": {
+    "minimum": "0.8.0",
+    "verified": "11"
+  },
   "esmodules": ["scripts/main.js"],
   "socket": true,
   "styles": ["styles/hourglass.css", "styles/hourglass-gui.css", "styles/flipdown.css"],
   "url": "https://github.com/Octarines/FoundryHourglass",
+  "readme": "https://raw.githubusercontent.com/Octarines/FoundryHourglass/main/README.md",
+  "bugs": "https://github.com/Octarines/FoundryHourglass/issues",
   "manifest": "https://github.com/Octarines/FoundryHourglass/releases/latest/download/module.json",
   "download": "This is auto replaced"
 }

--- a/module.json
+++ b/module.json
@@ -8,8 +8,8 @@
   }],
   "version": "This is auto replaced",
   "compatibility": {
-    "minimum": "11",
-    "verified": "11"
+    "minimum": 10,
+    "verified": 11
   },
   "esmodules": ["scripts/main.js"],
   "socket": true,


### PR DESCRIPTION
Updated the manifest for v11, since Foundry will otherwise complain in a warning:
> The module "hourglass" is using the old flat core compatibility fields which are deprecated in favor of the new "compatibility" object

Fixes #18 

### Specific changes:
- `name` is deprecated in favour of `id`
- `author` string is generalised to the `authors` array of objects (nabbed your email from your Github profile; apologies if you'd rather keep that off here 😅)
- The compatibility properties are consolidated into a new, single object (see warning above). Since this manifest format is unsupported by <v10, this change would make the module technically exclusive to v10 and higher. I personally don't see an issue with this, as older versions will obviously still be available in the GitHub releases, and current formats should be preferred over legacy, but just mentioning for transparency. 
- Added the `readme` and `bugs` properties because they're available and why not