### PR TITLE
Update for v12

### DIFF
--- a/module.json
+++ b/module.json
@@ -1,15 +1,21 @@
 {
-  "name": "hourglass",
+  "id": "hourglass",
   "title": "Hourglass",
   "description": "Configurable animated graphical timers & round trackers that can be shown by the GM to all players.",
-  "author": "Octarine",
+  "authors": [{
+    "name": "Octarine"
+  }],
   "version": "This is auto replaced",
-  "minimumCoreVersion": "0.8.0",
-  "compatibleCoreVersion": "11",
+  "compatibility": {
+    "minimum": "10",
+    "verified": "12"
+  },
   "esmodules": ["scripts/main.js"],
   "socket": true,
   "styles": ["styles/hourglass.css", "styles/hourglass-gui.css", "styles/flipdown.css"],
   "url": "https://github.com/Octarines/FoundryHourglass",
+  "readme": "https://raw.githubusercontent.com/Octarines/FoundryHourglass/main/README.md",
+  "bugs": "https://github.com/Octarines/FoundryHourglass/issues",
   "manifest": "https://github.com/Octarines/FoundryHourglass/releases/latest/download/module.json",
   "download": "This is auto replaced"
 }

--- a/scripts/hourglass-gui.js
+++ b/scripts/hourglass-gui.js
@@ -44,7 +44,7 @@ export class HourglassGui extends FormApplication {
   };
 
   static get defaultOptions() {
-    return mergeObject(super.defaultOptions, {
+    return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ['hourglass-gui'],
       popOut: true,
       template: './modules/hourglass/templates/hourglass-gui.html',


### PR DESCRIPTION
Basic manifest update, plus a quick fix for a deprecated `globalThis.mergeObject` call. Many thanks to @Spappz for his PR #17, which was used as the basis for this one.